### PR TITLE
Fix spacing between links and punctuation

### DIFF
--- a/src/routes/dataspace/+page.svelte
+++ b/src/routes/dataspace/+page.svelte
@@ -37,17 +37,17 @@
   <p>
     All the parties host their own public keys using
     <A href="https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-key-set-properties">
-      JSON Web Key Sets
-    </A>, which then are used for verifying tokens and messages, as well as encryption, whenever it
-    is needed. Trust in JWKS is brought by the existing mechanisms on the internet,
+      JSON Web Key Sets</A
+    >, which then are used for verifying tokens and messages, as well as encryption, whenever it is
+    needed. Trust in JWKS is brought by the existing mechanisms on the internet,
     <A href="https://www.cloudflare.com/en-gb/dns/dnssec/how-dnssec-works/">DNSSEC</A>,
     <A href="https://www.websecurity.digicert.com/security-topics/what-is-ssl-tls-https">
       SSL certificates
     </A>
     (incl.
     <A href="https://www.rapidsslonline.com/ssl/ev-ssl-certificate-requirements/">
-      Extended Validation
-    </A>), and so on.
+      Extended Validation</A
+    >), and so on.
   </p>
   <p>
     <A href="https://jwt.io/introduction/">JSON Web Tokens</A>,
@@ -81,8 +81,8 @@
     products on the Dataspace in the <A
       href="https://github.com/ioxio-dataspace/definitions-template"
     >
-      Definitions repository
-    </A>, and the results are published on the Dataspace so everyone can easily follow the agreed
+      Definitions repository</A
+    >, and the results are published on the Dataspace so everyone can easily follow the agreed
     standards. You will find the currently available data definitions on the
     <A href="https://definitions.sandbox.ioxio-dataspace.com/">Definitions Viewer</A>, and technical
     details in the
@@ -205,8 +205,8 @@
         You can check the source from GitHub, and to help you create your own productizer, you can
         go and check out our guide on
         <A href="https://docs.ioxio.dev/guides/building-a-data-source/">
-          how to build a data source
-        </A>.
+          how to build a data source</A
+        >.
       </p>
       <div class="example-links">
         <IconLink href="https://github.com/ioxio-dataspace/example-productizer" icon={ArrowIcon}>

--- a/src/routes/guides/building-a-data-definition/+page.svelte
+++ b/src/routes/guides/building-a-data-definition/+page.svelte
@@ -684,8 +684,8 @@ git push --set-upstream origin adding-my-definition
     <A
       href="https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository"
     >
-      pushing commits to a remote repository
-    </A>.
+      pushing commits to a remote repository</A
+    >.
   </p>
   <h3>Create a pull request</h3>
   <p>

--- a/src/routes/guides/using-login-provider/+page.svelte
+++ b/src/routes/guides/using-login-provider/+page.svelte
@@ -53,8 +53,8 @@
       For a really simple example of how the code flow authentication can be built, you can have a
       look at the codebase for the
       <A href="https://github.com/ioxio-dataspace/mycompany-consent-demo">
-        My Company Consent demo application
-      </A>. It's lacking a lot of cleanup related things, but should be enough to show how you could
+        My Company Consent demo application</A
+      >. It's lacking a lot of cleanup related things, but should be enough to show how you could
       build it.
     </p>
     <SectionTitle title="OpenID Configurations" />
@@ -64,8 +64,8 @@
       for example on the sandbox at the address <A
         href="https://login.sandbox.ioxio-dataspace.com/.well-known/openid-configuration"
       >
-        https://login.sandbox.ioxio-dataspace.com/.well-known/openid-configuration
-      </A>.
+        https://login.sandbox.ioxio-dataspace.com/.well-known/openid-configuration</A
+      >.
     </p>
     <p>The content looks like this:</p>
     <Code lang={json}>
@@ -101,8 +101,8 @@
     </p>
     <p>
       1. Login in to the <A href="https://developer.sandbox.ioxio-dataspace.com/">
-        Developer portal
-      </A>.
+        Developer portal</A
+      >.
     </p>
     <p>2. Go to the <em>My applications</em> page in the menu.</p>
     <GuideImage img={images.MY_APPLICATIONS_PAGE} />

--- a/src/routes/guides/verifying-consent-in-data-source/+page.svelte
+++ b/src/routes/guides/verifying-consent-in-data-source/+page.svelte
@@ -66,8 +66,8 @@
   <p>
     You most likely want to use one of the libraries for your programming language rather than try
     to implement it according to the <A href="https://datatracker.ietf.org/doc/html/rfc7519">
-      RFC 7519
-    </A>.
+      RFC 7519</A
+    >.
   </p>
   <p>
     Let's have a look at a valid example token from one of the applications on the IOXIO Sandbox
@@ -122,8 +122,8 @@ eyJhbGciOiJSUzI1NiIsImprdSI6Imh0dHBzOi8vY29uc2VudC5zYW5kYm94LmlveGlvLWRhdGFzcGFj
     <A
       href="https://consent.sandbox.ioxio-dataspace.com/.well-known/dataspace/consent-configuration.json"
     >
-      https://consent.sandbox.ioxio-dataspace.com/.well-known/dataspace/consent-configuration.json
-    </A>. At the time of writing this it returned this JSON content (formatted for readability):
+      https://consent.sandbox.ioxio-dataspace.com/.well-known/dataspace/consent-configuration.json</A
+    >. At the time of writing this it returned this JSON content (formatted for readability):
   </p>
   <Code lang={json}>
     {`
@@ -184,8 +184,8 @@ eyJhbGciOiJSUzI1NiIsImprdSI6Imh0dHBzOi8vY29uc2VudC5zYW5kYm94LmlveGlvLWRhdGFzcGFj
     <A
       href="https://pyjwt.readthedocs.io/en/stable/usage.html#retrieve-rsa-signing-keys-from-a-jwks-endpoint"
     >
-      retrieving the keys from a JWKS endpoint
-    </A>, thus it's worth checking if the library you are using has support for that before
+      retrieving the keys from a JWKS endpoint</A
+    >, thus it's worth checking if the library you are using has support for that before
     implementing it yourself.
   </p>
   <SectionTitle title="Caching" />
@@ -234,10 +234,10 @@ eyJhbGciOiJSUzI1NiIsImprdSI6Imh0dHBzOi8vY29uc2VudC5zYW5kYm94LmlveGlvLWRhdGFzcGFj
     consent.
   </p>
   <p>
-    If your data source also requires authorization, you should also
+    If your data source also requires authorization, you should also see
     <A href={GUIDES.VERIFY_ID_TOKEN.href}>
-      {GUIDES.VERIFY_ID_TOKEN.title}
-    </A>. Check the
+      {GUIDES.VERIFY_ID_TOKEN.title}</A
+    >. Check the
     <em>sub</em> of both tokens match and ensure the <em>app</em> in the consent token matches the
     <em>aud</em>
     of the id_token and the <em>subiss</em> in the consent token matches the <em>iss</em> in the id_token.

--- a/src/routes/guides/verifying-id-token/+page.svelte
+++ b/src/routes/guides/verifying-id-token/+page.svelte
@@ -64,15 +64,15 @@
     illustrated in the <A
       href="https://github.com/tiangolo/fastapi/blob/0.71.0/tests/test_security_http_bearer.py#L7-L12"
     >
-      HTTPBearer test cases
-    </A>. However you would likely want to adapt that slightly to make it an optional dependency for
+      HTTPBearer test cases</A
+    >. However you would likely want to adapt that slightly to make it an optional dependency for
     easier reuse.
   </p>
   <h3>Reading the id_token</h3>
   <p>
     The <em>id_token</em> is a <A href="https://datatracker.ietf.org/doc/html/rfc7519">
-      JSON Web Token (JWT)
-    </A>.
+      JSON Web Token (JWT)</A
+    >.
   </p>
   <p>
     If you are unfamiliar with JWTs you might want to check out the
@@ -166,8 +166,8 @@
     should be found on the sub-path <em>/.well-known/openid-configuration</em>
     relative to the <em>iss</em>. Thus in this case the the OpenID configuration can be fetched from
     <A href="https://login.sandbox.ioxio-dataspace.com/.well-known/openid-configuration">
-      https://login.sandbox.ioxio-dataspace.com/.well-known/openid-configuration
-    </A>. At the time of writing this it returned this JSON content (formatted for readability):
+      https://login.sandbox.ioxio-dataspace.com/.well-known/openid-configuration</A
+    >. At the time of writing this it returned this JSON content (formatted for readability):
   </p>
   <Code lang={json}>
     {`


### PR DESCRIPTION
In many cases there was an extra space before a dot/period and comma after links.